### PR TITLE
Allow developers to change styles by adding heavens-door-custom class

### DIFF
--- a/lib/heavens_door/middleware.rb
+++ b/lib/heavens_door/middleware.rb
@@ -19,7 +19,7 @@ module HeavensDoor
         end
 
         body.sub!(/<\/head[^>]*>/) { %Q[<link rel="stylesheet" href="/assets/heavens_door.css" /><script src="/assets/heavens_door.js"></script>\n#{$~}] }
-        body.sub!(/<body[^>]*>/) { %Q[#{$~}\n<div id="heavens-door"><span id="heavens-door-start">⏺</span><span id="heavens-door-stop">⏹</span><span id="heavens-door-copy">📋</span></div>] }
+        body.sub!(/<body[^>]*>/) { %Q[#{$~}\n<div id="heavens-door" class="heavens-door-custom"><span id="heavens-door-start">⏺</span><span id="heavens-door-stop">⏹</span><span id="heavens-door-copy">📋</span></div>] }
 
         [status, headers, [body]]
       else


### PR DESCRIPTION
I tried this gem but heavens-door's buttons are hidden by my application header.
This trouble can be avoided by adding some style as below.
For now, we need `!important` to overwrite default style.

```css
#heavens-door {
  top: 100px !important;
}
```

Or we need some html condition like `div#heavens-door`.

These workarounds seems not elegant.

By adding heavens-door-custom class, we can omit `!important` and html condition.

```css
#heavens-door.heavens-door-custom {
  top: 100px;
}
```

How about adding heavens-door-custom class?