### PR TITLE
Set z-index to avoid other HTML elements hide buttons

### DIFF
--- a/app/assets/stylesheets/heavens_door.css
+++ b/app/assets/stylesheets/heavens_door.css
@@ -1,1 +1,1 @@
-#heavens-door { position: absolute; top: 0; right: 0; font-size: 13px; cursor: pointer; } #heavens-door-stop,#heavens-door-copy { display: none; }
+#heavens-door { position: absolute; top: 0; right: 0; font-size: 13px; cursor: pointer; z-index: 9999; } #heavens-door-stop,#heavens-door-copy { display: none; }


### PR DESCRIPTION
I found a case HTML elements hide buttons. 
(The picture in below indicates that buttons exist but a header hides them.)

![image](https://user-images.githubusercontent.com/2294362/52172784-069f1500-27ba-11e9-8134-a85cf4af0f9c.png)

To avoid it, I add z-index property. 
I know we can set z-index to heavens-door-custom class, but I think it is natural that z-index exists defaultly.