### PR TITLE
Button position for recording and copy Clipboard

### DIFF
--- a/app/assets/stylesheets/heavens_door.css
+++ b/app/assets/stylesheets/heavens_door.css
@@ -1,1 +1,1 @@
-#heavens-door { position: absolute; top: 0; right: 0; font-size: 13px; cursor: pointer; } #heavens-door-stop,#heavens-door-copy { display: none; }
+#heavens-door { position: fixed; top: 10px; right: 10px; font-size: 13px; cursor: pointer; } #heavens-door-stop,#heavens-door-copy { display: none; }


### PR DESCRIPTION
Changed to positon fixed. (This change is necessary if the forms are
too long);

![untitled](https://user-images.githubusercontent.com/1373275/52177612-1ca0db80-27a2-11e9-865f-f4d3de515bc1.gif)

Added 10px to the top and right position. (This fixes the problem of
Scrool in Mac browsers).

![screen shot 2019-02-03 at 10 41 02 am](https://user-images.githubusercontent.com/1373275/52177548-5e7d5200-27a1-11e9-864c-22dfdc001c7f.png)
