### PR TITLE
Avoid modifying body when it frozened

### DIFF
--- a/lib/heavens_door/middleware.rb
+++ b/lib/heavens_door/middleware.rb
@@ -18,8 +18,10 @@ module HeavensDoor
           body = body[0]
         end
 
-        body.sub!(/<\/head[^>]*>/) { %Q[<link rel="stylesheet" href="/assets/heavens_door.css" /><script src="/assets/heavens_door.js"></script>\n#{$~}] }
-        body.sub!(/<body[^>]*>/) { %Q[#{$~}\n<div id="heavens-door" class="heavens-door-custom"><span id="heavens-door-start">⏺</span><span id="heavens-door-stop">⏹</span><span id="heavens-door-copy">📋</span></div>] }
+        unless body.frozen?
+          body.sub!(/<\/head[^>]*>/) { %Q[<link rel="stylesheet" href="/assets/heavens_door.css" /><script src="/assets/heavens_door.js"></script>\n#{$~}] }
+          body.sub!(/<body[^>]*>/) { %Q[#{$~}\n<div id="heavens-door" class="heavens-door-custom"><span id="heavens-door-start">⏺</span><span id="heavens-door-stop">⏹</span><span id="heavens-door-copy">📋</span></div>] }
+        end
 
         [status, headers, [body]]
       else


### PR DESCRIPTION
When the "body String" being frozen, middleware code return errors.

<img width="1245" alt="2019-02-05 9 54 23" src="https://user-images.githubusercontent.com/16287119/52247196-438b1900-292c-11e9-8b76-4c659f6a69bd.png">

I found this happens when the page is redirected.
In this case, the body is frozend for some reason.
Below is result of "binding.pry" when redirecting.

```
> body
=> "<html><body>You are being <a href=\"http://localhost:3000/mypage\">redirected</a>.</body></html>"

> body.frozen?
=> true
```

I wonder I should have write "if status is not redirect status", instead of " if it frozened", but I'm not clear about it.

What do you think?