### PR TITLE
Fix to delete item of sessionStorage more safely

### DIFF
--- a/app/assets/javascripts/heavens_door.js
+++ b/app/assets/javascripts/heavens_door.js
@@ -24,7 +24,7 @@
     document.getElementById('heavens-door-start').style.display = 'inline';
     document.getElementById('heavens-door-stop').style.display = 'none';
     document.getElementById('heavens-door-copy').style.display = 'none';
-    sessionStorage.clear('heavensDoor');
+    sessionStorage.removeItem('heavensDoor');
   });
 
   document.getElementById('heavens-door-copy').addEventListener('click', () => {


### PR DESCRIPTION
## Reason for this PR
`sessionStorage.clear()` is delete all items of sessionStorage.
However, `sessionStorage.removeItem(keyName)` is delete specific item of sessionStorage.
