### PR TITLE
Use `document.execCommand` instead of Clipboard API to copy text

### DIFF
--- a/app/assets/javascripts/heavens_door.js
+++ b/app/assets/javascripts/heavens_door.js
@@ -37,11 +37,17 @@
   });
 
   copyButton.addEventListener('click', () => {
-    navigator.clipboard.writeText(sessionStorage.heavensDoor)
-      .catch(err => {
-        console.error('Could not copy text: ', err);
-        alert(sessionStorage.heavensDoor);
-      });
+    const textarea = document.createElement('textarea');
+    textarea.value = sessionStorage.heavensDoor;
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    if (!document.execCommand('copy')) {
+      console.error('Could not copy text because `copy` command is unsupported or disabled');
+      alert(sessionStorage.heavensDoor);
+    }
+
+    document.body.removeChild(textarea);
   });
 
   if (sessionStorage.heavensDoor) {


### PR DESCRIPTION
When I was running Rails server with `rails s -b 192.168.1.2`, I got the following error on Chrome (Firefox and Safari also raise the similar error):

```
Uncaught TypeError: Cannot read property 'writeText' of undefined
    at HTMLSpanElement.<anonymous> (heavens_door.js:40)
```

It looks like [Clipboard](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard) only works localhost or secure environments(https), so I tried to use `document.execCommand` instead of it.

```
# Add logs to `copyButton#click`
# https://github.com/amatsuda/heavens_door/blob/f4afbf7c6bf068a8ce7c715e08e5284fb877f65a/app/assets/javascripts/heavens_door.js#L39
console.log("window.isSecureContext:", window.isSecureContext)
console.log("navigator.clipboard:", navigator.clipboard)

# Chrome only works
navigator.permissions.query({ name: 'clipboard-write' }).then(permissionStatus => {
  console.log("permissionStatus:", permissionStatus.state);
})

# http://localhost:3000
window.isSecureContext: true
navigator.clipboard: Clipboard { ... }
permissionStatus: granted

# http://192.168.1.2:3000
window.isSecureContext: false
navigator.clipboard: undefined
permissionStatus: denied
```

---

References

- [Unblocking Clipboard Access | Web | Google Developers](https://developers.google.com/web/updates/2018/03/clipboardapi)
- [Clipboard - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard)
  - [Clipboard API - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API)
  - [Permissions API - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API)
- [Document.execCommand() - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand)
- [Interact with the clipboard - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard)
- [Window.isSecureContext - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/isSecureContext)
  - [Secure contexts - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)

---

Environments

- Rails: 5.2.3
- heavens_door: 0.2.2
- Checked Browsers: latest Chrome, Safari, Firefox
