### PR TITLE
Use name attribute when label and id are missing

### DIFF
--- a/app/assets/javascripts/heavens_door.js
+++ b/app/assets/javascripts/heavens_door.js
@@ -59,7 +59,7 @@
     form.addEventListener('submit', () => {
       if (sessionStorage.heavensDoor) {
         Array.from(form.querySelectorAll('input,textarea,select')).forEach(el => {
-          const target = labelIdForElement(el) || el.id;
+          const target = labelIdForElement(el) || el.id || el.name;
 
           if (['text', 'textarea', 'search', 'number', 'email', 'url', 'password', 'tel'].includes(el.type)) {
             if (el.value) {


### PR DESCRIPTION
When label and id are missing, empty string was copied.
This PR supports `name` attribute when they are missing.

Before

```
<%= form.text_field :name, id: nil %> #=> fill_in '', with: 'test'
```

After

```
<%= form.text_field :name, id: nil %> #=> fill_in 'user[name]', with: 'test'
```