### PR TITLE
use text for select box option

### DIFF
--- a/app/assets/javascripts/heavens_door.js
+++ b/app/assets/javascripts/heavens_door.js
@@ -68,10 +68,10 @@
           } else if (el.type == 'date') {
             sessionStorage.heavensDoor += `    fill_in '${target}', with: Date.parse('${el.value}')\n`;
           } else if (el.type == 'select-one') {
-            sessionStorage.heavensDoor += `    select '${el[el.selectedIndex].value}', from: '${target}'\n`;
+            sessionStorage.heavensDoor += `    select '${el[el.selectedIndex].text}', from: '${target}'\n`;
           } else if (el.type == 'select-multiple') {
             Array.from(el.selectedOptions).forEach(o => {
-              sessionStorage.heavensDoor += `    select '${o.value}', from: '${target}'\n`;
+              sessionStorage.heavensDoor += `    select '${o.text}', from: '${target}'\n`;
             })
           } else if ((el.type == 'radio') && el.checked) {
             sessionStorage.heavensDoor += `    choose '${el.value}'\n`;


### PR DESCRIPTION
This PR makes the following changes :
(As the Capybara doc mentioned that select options should be found by text rather than value.)

**before**
`select 'value', from: 'select'`

**after**
`select 'text', from: 'select'`

Reference:
https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Actions
>The option can be found by its text.