### PR TITLE
Retrieve body successfully if `Rack::BodyProxy`

### DIFF
--- a/lib/heavens_door/middleware.rb
+++ b/lib/heavens_door/middleware.rb
@@ -15,7 +15,7 @@ module HeavensDoor
         case body
         when ActionDispatch::Response, ActionDispatch::Response::RackBody
           body = body.body
-        when Array
+        when Array, Rack::BodyProxy
           body = body[0]
         end
 


### PR DESCRIPTION
I run into an issue on Rails 6.0.3.1 where `heavens_door` fails if the body is a `Rack::BodyProxy`. It seems that the solution is simply considering this in [this case statement](https://github.com/amatsuda/heavens_door/blob/master/lib/heavens_door/middleware.rb#L18).

@amatsuda Thoughts?

Thanks for this amazing gem. ❇️ 