### PR TITLE
Add compatibility with turbo-rails

### DIFF
--- a/app/assets/javascripts/heavens_door.js
+++ b/app/assets/javascripts/heavens_door.js
@@ -11,6 +11,8 @@
       }
     } else {  // no turbolinks
       document.addEventListener('DOMContentLoaded', fn);
+      // Turbo is not yet available for detection here, need to attach the listener anyway
+      document.documentElement.addEventListener('turbo:load', fn);
     }
   }
 })(() => {

--- a/lib/heavens_door/engine.rb
+++ b/lib/heavens_door/engine.rb
@@ -7,7 +7,9 @@ module HeavensDoor
     initializer 'HeavensDoor' do |app|
       app.middleware.use HeavensDoor::Middleware
 
-      app.config.assets.precompile += %w(heavens_door.js heavens_door.css)
+      if !defined?(Propshaft)
+        app.config.assets.precompile += %w(heavens_door.js heavens_door.css)
+      end
     end
   end
 end

--- a/lib/heavens_door/middleware.rb
+++ b/lib/heavens_door/middleware.rb
@@ -20,7 +20,9 @@ module HeavensDoor
         end
 
         body = body.dup if body.frozen?
-        body.sub!(/<\/head[^>]*>/) { %Q[<link rel="stylesheet" href="#{Rails.application.config.assets.prefix}/heavens_door.css" /><script src="#{Rails.application.config.assets.prefix}/heavens_door.js"></script>\n#{$~}] }
+        if !defined?(Propshaft)
+          body.sub!(/<\/head[^>]*>/) { %Q[<link rel="stylesheet" href="#{Rails.application.config.assets.prefix}/heavens_door.css" /><script src="#{Rails.application.config.assets.prefix}/heavens_door.js"></script>\n#{$~}] }
+        end
         body.sub!(/<body[^>]*>/) { %Q[#{$~}\n<div id="heavens-door" class="heavens-door-custom"><span id="heavens-door-open" class="heavens-door-button">⏺</span><span id="heavens-door-close" class="heavens-door-button">⏹</span><span id="heavens-door-copy" class="heavens-door-button">📋</span></div>] }
 
         [status, headers, [body]]


### PR DESCRIPTION
This PR adds compatibility with the `turbo-rails` gem, which is now included in Rails by default.